### PR TITLE
Configure JSON as default serializer

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[1.5.0, 2)" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="[4.1.2, 5.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />

--- a/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[2.2.0, 3)" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[1.5.0, 2)" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="[4.1.2, 5.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />

--- a/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -35,6 +35,8 @@
             var recoverability = AdvancedConfiguration.Recoverability();
             recoverability.Immediate(settings => settings.NumberOfRetries(5));
             recoverability.Delayed(settings => settings.NumberOfRetries(3));
+
+            EndpointConfiguration.UseSerialization<NewtonsoftSerializer>();
         }
 
         /// <summary>

--- a/src/ServiceBus.Tests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.Tests/FunctionEndpointComponent.cs
@@ -53,7 +53,6 @@
                 endpoint = new TestableFunctionEndpoint(context =>
                 {
                     var functionEndpointConfiguration = new ServiceBusTriggeredEndpointConfiguration(Name);
-                    functionEndpointConfiguration.UseSerialization<NewtonsoftSerializer>();
 
                     var endpointConfiguration = functionEndpointConfiguration.AdvancedConfiguration;
 

--- a/src/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/src/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NServiceBus" Version="7.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.3.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>


### PR DESCRIPTION
Configures JSON as the default serializer, using the NServiceBus.Newtonsoft.Json package as a new dependency. We concluded that the vast majority of users will be using JSON and we can eliminate noisy boiler-plate code for the mandatory serializer configuration by using JSON as a useful default.
The serializer can still be changed, this only introduces an additional package dependency to NServiceBus.Newtonsoft.Json, Newtonsoft.JSON is already a transitive dependency due to the Microsoft.Azure.WebJobs packages.

For the future, it would be more appropriate to use the built-in JSON serializer from .NET Core which should probably not be a major problem as community packages are already making use of this. However, there is no clear understanding of potential compatibility issues so this is scoped out for now. A dedicated issue will be raised to handle the adoption of the native JSON serializer.