### PR TITLE
Saga acceptance test

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
@@ -18,8 +18,6 @@
         {
             EndpointConfiguration = new EndpointConfiguration(endpointName);
 
-            EndpointConfiguration.UsePersistence<InMemoryPersistence>();
-
             EndpointConfiguration.Recoverability().Delayed(c => c.NumberOfRetries(0));
 
             recoverabilityPolicy.SendFailedMessagesToErrorQueue = true;

--- a/src/ServiceBus.Tests/DefaultEndpoint.cs
+++ b/src/ServiceBus.Tests/DefaultEndpoint.cs
@@ -20,7 +20,6 @@
             configuration.EnableInstallers();
 
             configuration.DisableFeature<TimeoutManager>();
-            configuration.UsePersistence<InMemoryPersistence>();
 
             configuration.RegisterComponents(c => c
                 .RegisterSingleton(runDescriptor.ScenarioContext.GetType(), runDescriptor.ScenarioContext));

--- a/src/ServiceBus.Tests/Extensions.cs
+++ b/src/ServiceBus.Tests/Extensions.cs
@@ -11,6 +11,13 @@
     {
         public static IEnumerable<Type> GetTypesScopedByTestClass(this EndpointCustomizationConfiguration endpointConfiguration)
         {
+            var types = endpointConfiguration.BuilderType.GetTypesScopedByTestClass();
+            types = types.Union(endpointConfiguration.TypesToInclude);
+            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+        }
+
+        public static IEnumerable<Type> GetTypesScopedByTestClass(this Type componentType)
+        {
             var assemblies = new AssemblyScanner().GetScannableAssemblies();
 
             var assembliesToScan = assemblies.Assemblies
@@ -19,11 +26,10 @@
             var types = assembliesToScan
                 .SelectMany(a => a.GetTypes());
 
-            types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+            types = types.Union(GetNestedTypeRecursive(componentType.DeclaringType, componentType));
 
-            types = types.Union(endpointConfiguration.TypesToInclude);
 
-            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+            return types.ToList();
         }
 
         static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)

--- a/src/ServiceBus.Tests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.Tests/FunctionEndpointComponent.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceBus.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Reflection;
@@ -9,6 +10,7 @@
     using Microsoft.Azure.ServiceBus;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Customization;
     using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
     using NServiceBus.Serialization;
@@ -17,36 +19,49 @@
 
     abstract class FunctionEndpointComponent : IComponentBehavior
     {
-        public FunctionEndpointComponent(object triggerMessage, Action<ServiceBusTriggeredEndpointConfiguration> configurationCustomization = null)
+        public FunctionEndpointComponent()
         {
-            this.triggerMessage = triggerMessage;
-            this.configurationCustomization = configurationCustomization ?? (_ => { });
+        }
+
+        public FunctionEndpointComponent(object triggerMessage)
+        {
+            Messages.Add(triggerMessage);
         }
 
         public Task<ComponentRunner> CreateRunner(RunDescriptor runDescriptor)
         {
-            return Task.FromResult<ComponentRunner>(new FunctionRunner(triggerMessage, configurationCustomization, runDescriptor.ScenarioContext));
+            return Task.FromResult<ComponentRunner>(
+                new FunctionRunner(
+                    Messages, 
+                    CustomizeConfiguration, 
+                    runDescriptor.ScenarioContext,
+                    GetType()));
         }
 
-        readonly Action<ServiceBusTriggeredEndpointConfiguration> configurationCustomization;
-        object triggerMessage;
+        public IList<object> Messages { get; } = new List<object>();
+
+        public Action<ServiceBusTriggeredEndpointConfiguration> CustomizeConfiguration { set; private get; } = (_ => { });
+
 
         class FunctionRunner : ComponentRunner
         {
             public FunctionRunner(
-                object triggerMessage,
+                IList<object> messages,
                 Action<ServiceBusTriggeredEndpointConfiguration> configurationCustomization,
-                ScenarioContext scenarioContext)
+                ScenarioContext scenarioContext,
+                Type functionComponentType)
             {
-                this.triggerMessage = triggerMessage;
+                this.messages = messages;
                 this.configurationCustomization = configurationCustomization;
                 this.scenarioContext = scenarioContext;
+                this.functionComponentType = functionComponentType;
+                this.Name = functionComponentType.FullName;
 
                 var serializer = new NewtonsoftSerializer();
                 messageSerializer = serializer.Configure(new SettingsHolder())(new MessageMapper());
             }
 
-            public override string Name => $"{triggerMessage.GetType().Name}Function";
+            public override string Name { get; }
 
             public override Task Start(CancellationToken token)
             {
@@ -56,6 +71,8 @@
                     functionEndpointConfiguration.UseSerialization<NewtonsoftSerializer>();
 
                     var endpointConfiguration = functionEndpointConfiguration.AdvancedConfiguration;
+
+                    endpointConfiguration.TypesToIncludeInScan(functionComponentType.GetTypesScopedByTestClass());
 
                     endpointConfiguration.Recoverability()
                         .Immediate(i => i.NumberOfRetries(0))
@@ -85,11 +102,14 @@
                 return Task.CompletedTask;
             }
 
-            public override Task ComponentsStarted(CancellationToken token)
+            public override async Task ComponentsStarted(CancellationToken token)
             {
-                var message = GenerateMessage(triggerMessage);
-                var context = new ExecutionContext();
-                return endpoint.Process(message, context);
+                foreach (var message in messages)
+                {
+                    var transportMessage = GenerateMessage(message);
+                    var context = new ExecutionContext();
+                    await endpoint.Process(transportMessage, context);
+                }
             }
 
             public override Task Stop()
@@ -129,7 +149,8 @@
 
             readonly Action<ServiceBusTriggeredEndpointConfiguration> configurationCustomization;
             readonly ScenarioContext scenarioContext;
-            object triggerMessage;
+            readonly Type functionComponentType;
+            IList<object> messages;
             FunctionEndpoint endpoint;
             IMessageSerializer messageSerializer;
         }

--- a/src/ServiceBus.Tests/When_message_fails_with_disabled_error_queue.cs
+++ b/src/ServiceBus.Tests/When_message_fails_with_disabled_error_queue.cs
@@ -14,7 +14,7 @@
             var exception = Assert.ThrowsAsync<Exception>(() =>
             {
                 return Scenario.Define<ScenarioContext>()
-                    .WithComponent(new FailingFunction(new TriggerMessage()))
+                    .WithComponent(new FailingFunction())
                     .Done(c => c.EndpointsStarted)
                     .Run();
             });
@@ -25,10 +25,12 @@
 
         class FailingFunction : FunctionEndpointComponent
         {
-            public FailingFunction(object triggerMessage) : base(triggerMessage, c =>
+            public FailingFunction()
             {
-                c.DoNotSendMessagesToErrorQueue();
-            }) { }
+                CustomizeConfiguration = c => c.DoNotSendMessagesToErrorQueue();
+
+                Messages.Add(new TriggerMessage());
+            }
 
             public class FailingHandler : IHandleMessages<TriggerMessage>
             {

--- a/src/ServiceBus.Tests/When_shipping_handlers_in_dedicated_assembly.cs
+++ b/src/ServiceBus.Tests/When_shipping_handlers_in_dedicated_assembly.cs
@@ -28,6 +28,7 @@
             {
                 var configuration = new ServiceBusTriggeredEndpointConfiguration("assemblyTest");
                 configuration.UseSerialization<XmlSerializer>();
+                configuration.EndpointConfiguration.UsePersistence<LearningPersistence>();
 
                 settings = configuration.AdvancedConfiguration.GetSettings();
                 return configuration;

--- a/src/ServiceBus.Tests/When_using_sagas.cs
+++ b/src/ServiceBus.Tests/When_using_sagas.cs
@@ -71,6 +71,7 @@
                 public Task Handle(ReadSagaDataValueMessage message, IMessageHandlerContext context)
                 {
                     testContext.CounterValue = Data.SomeCounter;
+                    MarkAsComplete();
                     return Task.CompletedTask;
                 }
             }

--- a/src/ServiceBus.Tests/When_using_sagas.cs
+++ b/src/ServiceBus.Tests/When_using_sagas.cs
@@ -28,7 +28,6 @@
         {
             public SendingFunction()
             {
-                //TODO use learning persistence?
                 CustomizeConfiguration = configuration => 
                     configuration.AdvancedConfiguration.UsePersistence<LearningPersistence>();
 

--- a/src/ServiceBus.Tests/When_using_sagas.cs
+++ b/src/ServiceBus.Tests/When_using_sagas.cs
@@ -1,0 +1,102 @@
+﻿namespace ServiceBus.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_sagas
+    {
+        [Test]
+        public async Task Should_invoke_saga_message_handlers()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithComponent(new SendingFunction())
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.AreEqual(42, context.CounterValue);
+        }
+
+        class Context : ScenarioContext
+        {
+            public int CounterValue { get; set; }
+        }
+
+        class SendingFunction : FunctionEndpointComponent
+        {
+            public SendingFunction()
+            {
+                //TODO use learning persistence?
+                CustomizeConfiguration = configuration => 
+                    configuration.AdvancedConfiguration.UsePersistence<LearningPersistence>();
+
+                var correlationProperty = Guid.NewGuid().ToString("N");
+                Messages.Add(new StartSagaMessage {CorrelationProperty = correlationProperty});
+                Messages.Add(new UpdateSagaMessage {CorrelationProperty = correlationProperty, UpdateValue = 42});
+                Messages.Add(new ReadSagaDataValueMessage {CorrelationProperty = correlationProperty});
+            }
+
+            public class DemoSaga : Saga<DemoSagaData>, 
+                IAmStartedByMessages<StartSagaMessage>, 
+                IHandleMessages<UpdateSagaMessage>,
+                IHandleMessages<ReadSagaDataValueMessage>
+            {
+                Context testContext;
+
+                public DemoSaga(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<DemoSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationProperty);
+                    mapper.ConfigureMapping<UpdateSagaMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationProperty);
+                    mapper.ConfigureMapping<ReadSagaDataValueMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationProperty);
+                }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    Data.SomeCounter = 1;
+                    return Task.CompletedTask;
+                }
+
+                public Task Handle(UpdateSagaMessage message, IMessageHandlerContext context)
+                {
+                    Data.SomeCounter = message.UpdateValue;
+                    return Task.CompletedTask;
+                }
+
+                public Task Handle(ReadSagaDataValueMessage message, IMessageHandlerContext context)
+                {
+                    testContext.CounterValue = Data.SomeCounter;
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class DemoSagaData : ContainSagaData
+            {
+                public string CorrelationProperty { get; set; }
+                public int SomeCounter { get; set; }
+            }
+        }
+
+        class StartSagaMessage : IMessage
+        {
+            public string CorrelationProperty { get; set; }
+        }
+
+        class UpdateSagaMessage : IMessage
+        {
+            public string CorrelationProperty { get; set; }
+            public int UpdateValue { get; set; }
+        }
+
+        class ReadSagaDataValueMessage : IMessage
+        {
+            public string CorrelationProperty { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Adds an acceptance tests using a saga in a function.
I had to adjust the acceptance testing a little bit:
* similar to core's endpoint tests, only include types in the test class for scanning to avoid issues with missing persistence configuration in other tests
* changed the API a bit to allow sending multiple messages to a function. Because we can completely await the processing of the message, this is fairly easy.

I've removed inmemory persistence as the default configured persistence as this would cause problems with the DI container when the user decides to configure a different saga persistence (which is what we would recommend). There doesn't seem to be a need to configure a default persisted with ASB transport, as ASB brings in many native capabilities that would otherwise require a persisted. Only when sagas are used, a persister configuration becomes necessary.

additional thoughts:
* configuring a saga persister requires the use of the `AdvancedConfiguration` API. Given Sagas might be a bit of an experiment edge case, that might be sufficient. Otherwise, we should consider pulling the persistence config API up to the top-level API too (similar to the serializer)