### PR TITLE
Change webjobs ASB dependency version from 4.1.2 to 4.1.0

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[2.2.0, 3)" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[1.5.0, 2)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="[4.1.2, 5.0.0)" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="[4.1.0, 5.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.8.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
I noticed that creating a new function project in VS used version 4.1.0 of the `Microsoft.Azure.WebJobs.Extensions.ServiceBus` package. This causes nugget errors because our package requires version 4.1.2+. But since our dependency is transitive and further down in the dependency chain, nuget will use 4.1.0 and warn about a package downgrade. To resolve this, users would have to explicitly update the package to 4.1.2 to make the nuget error go away.

Should be ported to ASQ as well if merged.