### PR TITLE
Add default license location to check

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
@@ -29,12 +29,11 @@
                 .UsingCustomDisplayName(functionAppName)
                 .UsingCustomIdentifier(DeterministicGuid.Create(functionAppName));
 
-            // look for licenses in these additional default locations:
-            EndpointConfiguration.LicensePath("license.xml");
-            var licenseText = Environment.GetEnvironmentVariable("NServiceBusLicense");
+            // Look for license as an environment variable
+            var licenseText = Environment.GetEnvironmentVariable("NSERVICEBUS_LICENSE");
             if (!string.IsNullOrWhiteSpace(licenseText))
             {
-               EndpointConfiguration.License(licenseText); 
+               EndpointConfiguration.License(licenseText);
             }
         }
 

--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
@@ -30,8 +30,8 @@
                 .UsingCustomIdentifier(DeterministicGuid.Create(functionAppName));
 
             // look for licenses in these additional default locations:
-            EndpointConfiguration.License("license.xml");
-            string licenseText = Environment.GetEnvironmentVariable("NServiceBusLicense");
+            EndpointConfiguration.LicensePath("license.xml");
+            var licenseText = Environment.GetEnvironmentVariable("NServiceBusLicense");
             if (!string.IsNullOrWhiteSpace(licenseText))
             {
                EndpointConfiguration.License(licenseText); 

--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
@@ -28,6 +28,14 @@
             EndpointConfiguration.UniquelyIdentifyRunningInstance()
                 .UsingCustomDisplayName(functionAppName)
                 .UsingCustomIdentifier(DeterministicGuid.Create(functionAppName));
+
+            // look for licenses in these additional default locations:
+            EndpointConfiguration.License("license.xml");
+            string licenseText = Environment.GetEnvironmentVariable("NServiceBusLicense");
+            if (!string.IsNullOrWhiteSpace(licenseText))
+            {
+               EndpointConfiguration.License(licenseText); 
+            }
         }
 
         internal EndpointConfiguration EndpointConfiguration { get; }


### PR DESCRIPTION
The built-in locations which are checked for licenses aren't useful when running in a Functions environment as it's checking `Environment.SpecialFolder.LocalApplicationData`, `Environment.SpecialFolder.CommonApplicationData` and `AppDomain.CurrentDomain.BaseDirectory` which are all not usable.

This PR additionally checks the following locations for licenses by default:
* Looks for a license in the environment variables
  * ~~This doesn't work when trying to add the license to the settings/local.settings.json as you need to provide the full XML content and that can't be embedded into a JSON file.~~

~~I'm on the fence about the environment variable support but the file option might be an easy way to provide and deploy a license along with a function?~~ Discussed and agreed that we'll follow Azure convention and scan for an environment variable/Azure Functions setting named `NSERVICEBUS_LICENSE`. This will also be more secure than expecting the license file to be packaged along with the bits and potentially leaking if committed.

TODO:
* [x] Port to ASQ --> PR https://github.com/Particular/NServiceBus.AzureFunctions.StorageQueues/pull/8
* [x] Update documentation --> PR https://github.com/Particular/docs.particular.net/pull/4879/commits/fcb3b206ab1f755301b24205954a3f3adfbbe100
* [x] verify behavior on Azure
