### PR TITLE
Disable diagnostics

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
@@ -23,6 +23,8 @@
             recoverabilityPolicy.SendFailedMessagesToErrorQueue = true;
             EndpointConfiguration.Recoverability().CustomPolicy(recoverabilityPolicy.Invoke);
 
+            // Disable diagnostics by default as it will fail to create the diagnostics file in the default path.
+            EndpointConfiguration.CustomDiagnosticsWriter(_ => Task.CompletedTask);
             // 'WEBSITE_SITE_NAME' represents an Azure Function App and the environment variable is set when hosting the function in Azure.
             var functionAppName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? Environment.MachineName;
             EndpointConfiguration.UniquelyIdentifyRunningInstance()

--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpointConfiguration.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Security.Cryptography;
     using System.Text;
+    using System.Threading.Tasks;
+    using Logging;
     using Serialization;
     using Transport;
 
@@ -24,7 +26,9 @@
             EndpointConfiguration.Recoverability().CustomPolicy(recoverabilityPolicy.Invoke);
 
             // Disable diagnostics by default as it will fail to create the diagnostics file in the default path.
+            // Can be overriden by ServerlessEndpointConfiguration.LogDiagnostics().
             EndpointConfiguration.CustomDiagnosticsWriter(_ => Task.CompletedTask);
+
             // 'WEBSITE_SITE_NAME' represents an Azure Function App and the environment variable is set when hosting the function in Azure.
             var functionAppName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? Environment.MachineName;
             EndpointConfiguration.UniquelyIdentifyRunningInstance()
@@ -74,6 +78,18 @@
         public void DoNotSendMessagesToErrorQueue()
         {
             recoverabilityPolicy.SendFailedMessagesToErrorQueue = false;
+        }
+
+        /// <summary>
+        /// Logs endpoint diagnostics information to the log. Diagnostics are logged on level <see cref="LogLevel.Info"/>.
+        /// </summary>
+        public void LogDiagnostics()
+        {
+            EndpointConfiguration.CustomDiagnosticsWriter(diagnostics =>
+            {
+                LogManager.GetLogger("StartupDiagnostics").Info(diagnostics);
+                return Task.CompletedTask;
+            });
         }
 
         readonly ServerlessRecoverabilityPolicy recoverabilityPolicy = new ServerlessRecoverabilityPolicy();

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -6,6 +6,7 @@ namespace NServiceBus.AzureFunctions.ServiceBus
         protected ServerlessEndpointConfiguration(string endpointName) { }
         public NServiceBus.EndpointConfiguration AdvancedConfiguration { get; }
         public void DoNotSendMessagesToErrorQueue() { }
+        public void LogDiagnostics() { }
         public NServiceBus.Serialization.SerializationExtensions<T> UseSerialization<T>()
             where T : NServiceBus.Serialization.SerializationDefinition, new () { }
         protected NServiceBus.TransportExtensions<TTransport> UseTransport<TTransport>()


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus.AzureFunctions.ServiceBus/issues/70 by disabling diagnostics by default. Users can opt-in into diagnostics information by calling `config.LogDiagnostics()` which will put the diagnostic information into the log stream. This hasn't been made the default as it causes a significant amount of log data every time the function endpoint is started and the log output is associated with the specific invocation which happens to start the endpoint, so it might be difficult to find the correct trigger which contains the diagnostics data. There is still the ability to override the configuration and use a custom diagnostic-persitence approach if needed.

TODO:
* [ ] update doc for new API
* [ ] Port to ASQ
* [ ] Fix on release branch