### PR TITLE
Invoke transport's infrastructure Start and Stop methods

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
@@ -18,7 +18,7 @@
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
             var baseTransportInfrastructure = baseTransport.Initialize(settings, connectionString);
-            return new ServerlessTransportInfrastructure<TBaseTransport>(baseTransportInfrastructure, settings);
+            return new ServerlessTransportInfrastructure(baseTransportInfrastructure, settings);
         }
 
         readonly TBaseTransport baseTransport;

--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/TransportWrapper/ServerlessTransportInfrastructure.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/TransportWrapper/ServerlessTransportInfrastructure.cs
@@ -2,14 +2,14 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Routing;
     using Settings;
     using Transport;
 
-    class ServerlessTransportInfrastructure<TBaseInfrastructure> : TransportInfrastructure
+    class ServerlessTransportInfrastructure : TransportInfrastructure
     {
-        public ServerlessTransportInfrastructure(TransportInfrastructure baseTransportInfrastructure,
-            SettingsHolder settings)
+        public ServerlessTransportInfrastructure(TransportInfrastructure baseTransportInfrastructure, SettingsHolder settings)
         {
             this.baseTransportInfrastructure = baseTransportInfrastructure;
             this.settings = settings;
@@ -43,6 +43,16 @@
         public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
         {
             return baseTransportInfrastructure.BindToLocalEndpoint(instance);
+        }
+
+        public override Task Start()
+        {
+            return baseTransportInfrastructure.Start();
+        }
+
+        public override Task Stop()
+        {
+            return baseTransportInfrastructure.Stop();
         }
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)


### PR DESCRIPTION
Invoke ASB transport infrastructure `Start()` and `Stop()` methods.
ASB's `Stop()` method is responsible for [closing message senders pool](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/blob/ed0cc09e334f18b9412606f6c9c236b6848af299/src/Transport/AzureServiceBusTransportInfrastructure.cs#L181-L187) which is used by ASB Functions for dispatching messages.