### PR TITLE
Exclude Microsoft.Data.SqlClient from assembly scanning

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/Serverless/ServerlessEndpoint.cs
@@ -118,6 +118,7 @@
                 case "cc7b13ffcd2ddd51":
                 case "adb9793829ddae60":
                 case "7e34167dcc6d6d8c": // Microsoft.Azure.ServiceBus
+                case "23ec7fc2d6eaa4a5": // Microsoft.Data.SqlClient
                 case "50cebf1cceb9d05e": // Mono.Cecil
                 case "30ad4fe6b2a6aeed": // Newtonsoft.Json
                 case "9fc386479f8a226c": // NServiceBus


### PR DESCRIPTION
Scanning the Microsoft.Data.SqlClient assembly in the bin folder causes a "platform not supported" exception. Since we have no need to scan this assembly, excluding it from the scanning process should solve the issue and e.g. allow to use Entity Framework Core with the NServiceBus Azure Functions package