### PR TITLE
Introduce interface for the function endpoint to simplify testing

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
@@ -18,7 +18,7 @@
     /// An NServiceBus endpoint hosted in Azure Function which does not receive messages automatically but only handles
     /// messages explicitly passed to it by the caller.
     /// </summary>
-    public class FunctionEndpoint
+    public class FunctionEndpoint : IFunctionEndpoint
     {
         /// <summary>
         /// Creates a new instance of <see cref="FunctionEndpoint" /> that can handle messages using the provided configuration.

--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.IO;
-using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection;
-
-namespace NServiceBus
+﻿namespace NServiceBus
 {
+    using System;
+    using System.IO;
+    using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection;
+
     /// <summary>
     /// Provides extension methods to configure a <see cref="FunctionEndpoint"/> using <see cref="IFunctionsHostBuilder"/>.
     /// </summary>
@@ -22,18 +22,20 @@ namespace NServiceBus
             var endpointFactory = Configure(serviceBusTriggeredEndpointConfiguration, functionsHostBuilder.Services,
                 Path.Combine(functionsHostBuilder.GetContext().ApplicationRootPath, "bin"));
 
+            // for backward compatibility
             functionsHostBuilder.Services.AddSingleton(endpointFactory);
+            functionsHostBuilder.Services.AddSingleton<IFunctionEndpoint>(sp => sp.GetRequiredService<FunctionEndpoint>());
         }
 
         internal static Func<IServiceProvider, FunctionEndpoint> Configure(
-            ServiceBusTriggeredEndpointConfiguration configuration, 
-            IServiceCollection serviceCollection, 
+            ServiceBusTriggeredEndpointConfiguration configuration,
+            IServiceCollection serviceCollection,
             string appDirectory)
         {
             FunctionEndpoint.LoadAssemblies(appDirectory);
 
             var startableEndpoint = EndpointWithExternallyManagedServiceProvider.Create(
-                    configuration.EndpointConfiguration, 
+                    configuration.EndpointConfiguration,
                     serviceCollection);
 
             return serviceProvider => new FunctionEndpoint(startableEndpoint, configuration, serviceProvider);

--- a/src/NServiceBus.AzureFunctions.ServiceBus/IFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/IFunctionEndpoint.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// An NServiceBus endpoint hosted in Azure Function which does not receive messages automatically but only handles
+    /// messages explicitly passed to it by the caller.
+    /// </summary>
+    public interface IFunctionEndpoint
+    {
+        /// <summary>
+        /// Processes a message received from an AzureServiceBus trigger using the NServiceBus message pipeline.
+        /// </summary>
+        Task Process(Message message, ExecutionContext executionContext, ILogger functionsLogger = null);
+    }
+}

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"ServiceBus.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 namespace NServiceBus
 {
-    public class FunctionEndpoint
+    public class FunctionEndpoint : NServiceBus.IFunctionEndpoint
     {
         protected System.Func<NServiceBus.FunctionExecutionContext, string> AssemblyDirectoryResolver;
         public FunctionEndpoint(System.Func<NServiceBus.FunctionExecutionContext, NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
@@ -16,6 +16,10 @@ namespace NServiceBus
     public static class FunctionsHostBuilderExtensions
     {
         public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, System.Func<NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
+    }
+    public interface IFunctionEndpoint
+    {
+        System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
     }
     public class ServiceBusTriggeredEndpointConfiguration
     {


### PR DESCRIPTION
Solves #113 

Given this is a preview it would be fine to release this as 0.3 right? If you agree with the changes I can also make the [same change for ASQ](https://github.com/Particular/NServiceBus.AzureFunctions.StorageQueues/pull/50)

Alternatively, we could make the Process method virtual but I think it would be more invasive because we would need to make sure production use cases off overriding those methods would be supported. 