### PR TITLE
Introduce support for operations outside of message handler

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
@@ -109,7 +109,7 @@
                         LogManager.GetLogger("Previews").Info(
                             "NServiceBus.AzureFunctions.ServiceBus is a preview package. Preview packages are licensed separately from the rest of the Particular Software platform and have different support guarantees. You can view the license at https://particular.net/eula/previews and the support policy at https://docs.particular.net/previews/support-policy. Customer adoption drives whether NServiceBus.AzureFunctions.ServiceBus will be incorporated into the Particular Software platform. Let us know you are using it, if you haven't already, by emailing us at support@particular.net.");
 
-                        var endpoint = await endpointFactory(executionContext).ConfigureAwait(false);
+                        endpoint = await endpointFactory(executionContext).ConfigureAwait(false);
 
                         pipeline = configuration.PipelineInvoker;
                     }
@@ -119,6 +119,107 @@
                     semaphoreLock.Release();
                 }
             }
+        }
+
+        /// <inheritdoc />
+        public async Task Send(object message, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Send(message, options).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public Task Send(object message, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            return Send(message, new SendOptions(), executionContext, functionsLogger);
+        }
+
+        /// <inheritdoc />
+        public async Task Send<T>(Action<T> messageConstructor, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Send(messageConstructor, options).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public Task Send<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            return Send(messageConstructor, new SendOptions(), executionContext, functionsLogger);
+        }
+
+        /// <inheritdoc />
+        public async Task Publish(object message, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Publish(message, options).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Publish<T>(Action<T> messageConstructor, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Publish(messageConstructor, options).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Publish(object message, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Publish(message).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Publish<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Publish(messageConstructor).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Subscribe(Type eventType, SubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Subscribe(eventType, options).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Subscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Subscribe(eventType).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Unsubscribe(Type eventType, UnsubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Unsubscribe(eventType, options).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task Unsubscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null)
+        {
+            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+
+            await endpoint.Unsubscribe(eventType).ConfigureAwait(false);
+        }
+
+        private async Task InitializeEndpointUsedOutsideHandlerIfNecessary(ExecutionContext executionContext, ILogger functionsLogger)
+        {
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
+
+            var functionExecutionContext = new FunctionExecutionContext(executionContext, functionsLogger);
+
+            await InitializeEndpointIfNecessary(functionExecutionContext).ConfigureAwait(false);
         }
 
         internal static void LoadAssemblies(string assemblyDirectory)
@@ -189,5 +290,6 @@
         private ServiceBusTriggeredEndpointConfiguration configuration;
 
         PipelineInvoker pipeline;
+        private IEndpointInstance endpoint;
     }
 }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/IFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/IFunctionEndpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus
+﻿using System;
+
+namespace NServiceBus
 {
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
@@ -15,5 +17,67 @@
         /// Processes a message received from an AzureServiceBus trigger using the NServiceBus message pipeline.
         /// </summary>
         Task Process(Message message, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Sends the provided message.
+        /// </summary>
+        Task Send(object message, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Sends the provided message.
+        /// </summary>
+        Task Send(object message, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it.
+        /// </summary>
+        Task Send<T>(Action<T> messageConstructor, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it.
+        /// </summary>
+        Task Send<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Publish the message to subscribers.
+        /// </summary>
+        Task Publish(object message, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        Task Publish<T>(Action<T> messageConstructor, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        Task Publish(object message, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        Task Publish<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Subscribes to receive published messages of the specified type.
+        /// This method is only necessary if you turned off auto-subscribe.
+        /// </summary>
+        Task Subscribe(Type eventType, SubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Subscribes to receive published messages of the specified type.
+        /// This method is only necessary if you turned off auto-subscribe.
+        /// </summary>
+        Task Subscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Unsubscribes to receive published messages of the specified type.
+        /// </summary>
+        Task Unsubscribe(Type eventType, UnsubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null);
+
+        /// <summary>
+        /// Unsubscribes to receive published messages of the specified type.
+        /// </summary>
+        Task Unsubscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null);
     }
 }

--- a/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/NServiceBus.AzureFunctions.ServiceBus.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="[1.1, 2)" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[2.2.0, 3)" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[1.5.0, 2)" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="[1.0,2)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="[4.1.0, 5.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.8.0" />
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.2.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.8.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -6,6 +6,18 @@ namespace NServiceBus
         protected System.Func<NServiceBus.FunctionExecutionContext, string> AssemblyDirectoryResolver;
         public FunctionEndpoint(System.Func<NServiceBus.FunctionExecutionContext, NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Publish(object message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Send(object message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Subscribe(System.Type eventType, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Unsubscribe(System.Type eventType, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
+        public System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
     }
     public class FunctionExecutionContext
     {
@@ -20,6 +32,18 @@ namespace NServiceBus
     public interface IFunctionEndpoint
     {
         System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Publish(object message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Send(object message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Subscribe(System.Type eventType, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
+        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null);
     }
     public class ServiceBusTriggeredEndpointConfiguration
     {

--- a/src/ServiceBus.Tests/DefaultEndpoint.cs
+++ b/src/ServiceBus.Tests/DefaultEndpoint.cs
@@ -31,9 +31,15 @@
 
             var transport = configuration.UseTransport<AzureServiceBusTransport>();
             transport.ConnectionString(Environment.GetEnvironmentVariable(ServiceBusTriggeredEndpointConfiguration.DefaultServiceBusConnectionName));
-            transport.RuleNameShortener(x => x
-                .Replace(typeof(DefaultEndpoint).Namespace, string.Empty)
-                .Replace("+", string.Empty));
+            transport.SubscriptionRuleNamingConvention(type =>
+            {
+                if (type.FullName.Length <= 50)
+                {
+                    return type.FullName;
+                }
+
+                return type.Name;
+            });
 
             configuration.UseSerialization<NewtonsoftSerializer>();
 
@@ -41,7 +47,5 @@
 
             return Task.FromResult(configuration);
         }
-
-        
     }
 }

--- a/src/ServiceBus.Tests/When_publishing_event_from_function_outside_handler.cs
+++ b/src/ServiceBus.Tests/When_publishing_event_from_function_outside_handler.cs
@@ -1,0 +1,55 @@
+﻿namespace ServiceBus.Tests
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_publishing_event_from_function_outside_handler
+    {
+        [Test]
+        public async Task Should_publish_to_subscribers()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SubscriberEndpoint>(b =>
+                    b.When(async session => await session.Publish(new TestEvent())))
+                .Done(c => c.EventReceived)
+                .Run();
+
+            Assert.IsTrue(context.EventReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool EventReceived { get; set; }
+        }
+
+        class SubscriberEndpoint : EndpointConfigurationBuilder
+        {
+            public SubscriberEndpoint()
+            {
+                EndpointSetup<DefaultEndpoint>();
+            }
+
+            public class EventHandler : IHandleMessages<TestEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(TestEvent message, IMessageHandlerContext context)
+                {
+                    testContext.EventReceived = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class TestEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceBus.Tests/When_sending_message_outside_handler.cs
+++ b/src/ServiceBus.Tests/When_sending_message_outside_handler.cs
@@ -1,0 +1,58 @@
+﻿namespace ServiceBus.Tests
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    public class When_sending_message_outside_handler
+    {
+        [Test]
+        public async Task Should_send_message_to_target_queue()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<ReceivingEndpoint>(b => b.When(async session =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToThisEndpoint();
+                    await session.Send(new TriggerMessage(), sendOptions);
+                }))
+                .Done(c => c.HandlerReceivedMessage)
+                .Run();
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool HandlerReceivedMessage { get; set; }
+        }
+
+        public class ReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public ReceivingEndpoint()
+            {
+                EndpointSetup<DefaultEndpoint>();
+            }
+
+            class TriggerMessageHandler : IHandleMessages<TriggerMessage>
+            {
+                Context testContext;
+
+                public TriggerMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(TriggerMessage message, IMessageHandlerContext context)
+                {
+                    testContext.HandlerReceivedMessage = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class TriggerMessage : IMessage
+        {
+        }
+    }
+}


### PR DESCRIPTION
Closes #82 

With this change, messages can be sent/published outside of the message handler, similar to what can be done with `IEndpointInstance` or `IMessageSession`. This enables scenarios such as dispatching messages from Timer and HTTP triggers, using both the static and `FunctionsHostBuilder` approach.

Using `FunctionsHostBuilder` approach with `HttpTrigger`:
![image](https://user-images.githubusercontent.com/1309622/103957797-bb5db180-5108-11eb-8054-c3f8f60a74ab.png)

Dispatching a message on `TimerTrigger`-ed Function:
![image](https://user-images.githubusercontent.com/1309622/103957866-e1835180-5108-11eb-955e-1eaa7b0a331a.png)